### PR TITLE
Push to both DockerHub and GHCR

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -25,8 +25,25 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       -
+        name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - 
+        name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            jammsen/palworld-dedicated-server
+            ghcr.io/${{ github.repository }}
+      -
         name: Build and push
         uses: docker/build-push-action@v4
         with:
+          context: .
           push: true
-          tags: jammsen/palworld-dedicated-server:latest
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Docs: https://docs.github.com/en/actions/publishing-packages/publishing-docker-images#publishing-images-to-docker-hub-and-github-packages

I've not done an end to end test of this since I don't have the full repo secrets for DH setup yet, if you would like me to do that (e.g. less work for you just incase there was a mistake here) I could, but it'll be at least a few more hours until I can do that.

Fixes #17 