### PR TITLE
fixed rcon not being deployed and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This includes a Palworld Dedicated Server based on Linux and Docker.
 | COMMUNITY_SERVER       | Sets the server to a "Community-Server". If true, the server will appear in the Community-Serverlist. Needs PUBLIC_IP and PUBLIC_PORT | true                                                   | false/true    |
 | RCON_ENABLED           | RCON function - use ADMIN_PASSWORD to login after enabling it                                                                         | true                                                   | false/true    |
 | RCON_PORT              | RCON port to connect to                                                                                                               | 25575                                                  | 1024-65535    |
-| PUBLIC_IP              | Public ip, auto-detect if not specified, see COMMUNITY_SERVER                                                                         | 10.0.0.1                                               | ip address    |
+| PUBLIC_IP or FQDN              | Public ip/FQDN, auto-detect if not specified, see COMMUNITY_SERVER                                                                         | 10.0.0.1 or palworld.server.com                                               | ip address or FQDN    |
 | PUBLIC_PORT            | Public port, auto-detect if not specified, see COMMUNITY_SERVER                                                                       | 8211                                                   | 1024-65535    |
 | SERVER_NAME            | Name of the server                                                                                                                    | jammsen-docker-generated-###RANDOM###                  | string        |
 | SERVER_DESCRIPTION     | Desription of the server                                                                                                              | Palworld-Dedicated-Server running in Docker by jammsen | string        |
@@ -60,7 +60,7 @@ services:
     build: .
     container_name: palworld-dedicated-server
     image: jammsen/palworld-dedicated-server:latest
-    restart: always
+    restart: unless-stopped
     network_mode: bridge
     ports:
       - target: 8211 # gamerserver port inside of the container
@@ -95,7 +95,7 @@ services:
     build: .
     container_name: palworld-dedicated-server
     image: jammsen/palworld-dedicated-server:latest
-    restart: always
+    restart: unless-stopped
     network_mode: bridge
     ports:
       - target: 8211 # gamerserver port inside of the container
@@ -124,8 +124,13 @@ services:
   
   rcon:
     image: outdead/rcon:latest
+    container_name: palworld-rcon
+    restart: unless-stopped
     entrypoint: ['/rcon', '-a', '10.0.0.5:25575', '-p', 'adminPasswordHere']
-    profiles: ['rcon'] 
+    tty: true
+    stdin_open: true
+    depends_on:
+      - palworld-dedicated-server
 ```
 The profiles defintion, prevents the container from starting with the server and in your console you can run now RCON commands via
 #### RCON


### PR DESCRIPTION
Hey there,

I’ve been working on some enhancements to the docker-compose setup for the RCON container, which will address the issue mentioned in #31.

Firstly, I noticed the “depends_on” flag was missing, which seemed to be causing some problems with pulling the container. I’ve added this into the configuration.

I’ve also enabled the TTY and stdin_open flags. This should make it easier to attach to the internal console whenever we need to. Plus, I’ve set the containers to not restart automatically when they’re stopped intentionally, which should help with debugging.

On another note, I found out that a Fully Qualified Domain Name (FQDN) works just as well as a public IP. I wasn’t sure about this at first, but after testing it out, it seems to work fine. I’ve updated the public IP category to reflect this.

Thanks for all your hard work on this project. It’s been great to contribute!