### PR TITLE
[RFC] Adding portainer to README.MD and homogenizing text

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,60 +5,64 @@
 ![Docker Pulls](https://img.shields.io/docker/pulls/jammsen/palworld-dedicated-server)
 ![Docker Stars](https://img.shields.io/docker/stars/jammsen/palworld-dedicated-server)
 ![Image Size](https://img.shields.io/docker/image-size/jammsen/palworld-dedicated-server/latest)
-This includes a Palworld Dedicated Server based on Linux and Docker.
+
+This Docker image includes a Palworld Dedicated Server based on Linux and Docker.
 
 ___
 
-## Overview
+## Table of Contents
 
-* [Do you need support for this Docker Image](#do-you-need-support-for-this-docker-image)
-* [What you need to run this](#what-you-need-to-run-this)
-* [Getting started](#getting-started)
-* [Environment-Variables](#environment-variables)
-  * [Container-Settings](#container-settings)
-    * [TZ identifiers](#tz-identifiers)
-    * [Cron expression](#cron-expression)  
-  * [Gameserver-Settings](#gameserver-settings)
-* [Docker-Compose examples](#docker-compose-examples)
-  * [Standalone gameserver](#standalone-gameserver)
-  * [Gameserver with RCON](#gameserver-with-rcon)
-   * [Run RCON commands](#run-rcon-commands)
-  * [Usage with Portainer - Soon TM](#usage-with-portainer)
-* [FAQ](#faq)
-* [Planned features in the future](#planned-features-in-the-future)
-* [Software used](#software-used)
+- [Support for this Docker Image](#do-you-need-support-for-this-docker-image)
+- [Requirements](#what-you-need-to-run-this)
+- [Getting Started](#getting-started)
+- [Environment Variables](#environment-variables)
+  - [Container Settings](#container-settings)
+    - [Timezone Identifiers](#tz-identifiers)
+    - [Cron Expressions](#cron-expression)  
+  - [Game Server Settings](#gameserver-settings)
+- [Docker-Compose Examples](#docker-compose-examples)
+  - [Standalone Game Server](#standalone-gameserver)
+  - [Game Server with RCON](#gameserver-with-rcon)
+    - [Running RCON Commands](#run-rcon-commands)
+  - [Usage with Portainer (Coming Soon)](#usage-with-portainer)
+- [Frequently Asked Questions](#faq)
+- [Future Plans](#planned-features-in-the-future)
+- [Software Used](#software-used)
 
-## Do you need support for this Docker Image
+## Support for this Docker Image
 
-- What to do?
-  - Feel free to create a NEW issue
-    - It is okay to "reference" that you might have the same problem as the person in issue #number
-  - Follow the instructions and answer the questions of people who are willing to help you
-  - If your issue is done, close it and please consider giving this repo and the [Docker-Hub repository](https://hub.docker.com/repository/docker/jammsen/palworld-dedicated-server) a star
-    - I will Inactivity-Close any issue thats not been active for a week
-- What NOT to do?
-  - Dont re-use issues / Dont necro!
-    - You are most likely to chat/spam/harrass thoose participants who didnt agree to be part of your / a new problem and might be totally out of context!
-  - If this happens, i reserve the rights to lock the issue or delete the comments, you have been warned!
+If you need support for this Docker image:
 
-## What you need to run this
+- Feel free to create a new issue. You can reference other issues if you're experiencing a similar problem.
+- Follow the instructions and answer the questions of people who are willing to help you.
+- Once your issue is resolved, close it. Please consider giving this repo and the [Docker-Hub repository](https://hub.docker.com/repository/docker/jammsen/palworld-dedicated-server) a star.
+- Please note that any issue that has been inactive for a week will be closed due to inactivity.
 
-- Basic understanding of Docker, Docker-Compose, Linux and Networking (Port-Forwarding/NAT)
+Please avoid:
 
-## Getting started
+- Reusing or necroing issues. This can lead to spam and may harass participants who didn't agree to be part of your new problem.
+- If this happens, we reserve the right to lock the issue or delete the comments.
 
-1. Create a `game` sub-directories on your Dockernode in your game-server-directory (Example: `/srv/palworld`) and give it with `chmod 777 game` full permissions or use `chown -R 1000:1000 game/`.
-2. Setup Port-Forwarding or NAT for the ports in the Docker-Compose file
-3. Pull the latest version of the image with `docker pull jammsen/palworld-dedicated-server:latest` 
-4. Setup your own docker-compose.yml just how you like it - Look into the [Docker-Compose examples](#examples) section and the [Environment-Variables](#examples) section for more information 
-5. Start the container via `docker-compose up -d && docker-compose logs -f` and watch the log, if no errors occur you can close the logs with ctrl+c 
-6. Happy gaming!
+## Requirements
 
-## Environment-Variables
+To run this Docker image, you need a basic understanding of Docker, Docker-Compose, Linux, and Networking (Port-Forwarding/NAT).
 
-**Imporant:** In this section you will find a lot of environment variables to control your container-behavior and gameserver-settings. But because of a lot of control, there comes a lot of settings, so this is split into 2 parts for documentation. First comes **Container-Settings** and second **Gamesserver-Settings**.
+## Getting Started
 
-### Container-Settings
+1. Create a `game` sub-directory on your Docker node in your game-server-directory (Example: `/srv/palworld`). Give it full permissions with `chmod 777 game` or use `chown -R 1000:1000 game/`.
+2. Set up Port-Forwarding or NAT for the ports in the Docker-Compose file.
+3. Pull the latest version of the image with `docker pull jammsen/palworld-dedicated-server:latest`.
+4. Set up your own docker-compose.yml as per your requirements. Refer to the [Docker-Compose examples](#examples) section and the [Environment-Variables](#examples) section for more information.
+5. Start the container via `docker-compose up -d && docker-compose logs -f`. Watch the log, if no errors occur you can close the logs with ctrl+c.
+6. Enjoy your game!
+
+## Environment Variables
+
+**Important:** This section contains numerous environment variables to control your container behavior and game server settings. Due to the extensive control options, the settings are split into two parts for documentation: **Container Settings** and **Game Server Settings**.
+
+## Container Settings
+
+These settings control the behavior of the Docker container:
 
 | Variable               | Description                                                         | Default value                  | Allowed value                         |
 | ---------------------- | ------------------------------------------------------------------- | ------------------------------ | ------------------------------------- |
@@ -69,23 +73,23 @@ ___
 | BACKUP_ENABLED         | Backup function, creates backups in your `game` directory           | true                           | false/true                            |
 | BACKUP_CRON_EXPRESSION | Needs a Cron-Expression - See [Cron expression](#cron-expression)   | 0 * * * * (meaning every hour) | Cron-Expression                       |
 
-#### TZ identifiers
+### TZ Identifiers
 
-This setting affects logging output and the backup function. [TZ identifiers](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#Time_Zone_abbreviations) are format of defining a timezone near you. 
+The `TZ` setting affects logging output and the backup function. [TZ identifiers](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones#Time_Zone_abbreviations) are a format for defining a timezone near you.
 
-#### Cron expression
+### Cron Expression
 
-This setting affects the backup function. In a Cron-Expression you define an interval for jobs to run. This image uses Supercronic for crons, see https://github.com/aptible/supercronic#crontab-format or https://crontab-generator.org
+The `BACKUP_CRON_EXPRESSION` setting affects the backup function. In a Cron-Expression, you define an interval for jobs to run. This image uses Supercronic for crons, see https://github.com/aptible/supercronic#crontab-format or https://crontab-generator.org
 
-### Gameserver-Settings
+## Game Server Settings
 
-This is a list of all the settings currently adjustable via Docker environment variables, based on the **order** and **contents of the DefaultPalWorldSettings.ini**
+This section lists all the settings currently adjustable via Docker environment variables, based on the **order** and **contents of the DefaultPalWorldSettings.ini**.
 
-Information-sources and credits to the following websites:
-* [Palworld Tech Guide](https://tech.palworldgame.com/optimize-game-balance) for the gameserver documentation
+Information sources and credits to the following websites:
+* [Palworld Tech Guide](https://tech.palworldgame.com/optimize-game-balance) for the game server documentation
 * [PalworldSettingGenerator](https://dysoncheng.github.io/PalWorldSettingGenerator/setting.html) for variable descriptions
 
-**Imporant:** Please note that all of this is subject to change. **The game is still in early access.**
+**Important:** Please note that all of this is subject to change. **The game is still in early access.**
 
 | Variable                                  | Game setting                         | Description                                                                                                                                                       | Default Value                                          | Allowed Value |
 | ----------------------------------------- | ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------ | ------------- |
@@ -146,7 +150,7 @@ Information-sources and credits to the following websites:
 | ADMIN_PASSWORD                            | server admin password                | AdminPassword                                                                                                                                                     | adminPasswordHere                                      | String        |
 | SERVER_PASSWORD                           | AdminPassword                        | Set the server password.                                                                                                                                          | serverPasswordHere                                     | String        |
 | PUBLIC_PORT                               | public port                          | Public port number                                                                                                                                                | 8211                                                   | Integer       |
-| PUBLIC_IP                                 | public ip                            | Public IP                                                                                                                                                         |                                                        | String        |
+| PUBLIC_IP                                 | public ip or FQDN                            | Public IP or FQDN                                                                                                                                                         |                                                        | String        |
 | RCON_ENABLED                              | RCONEnabled                          | Enable RCON - Use ADMIN_PASSWORD to login                                                                                                                         | false                                                  | Boolean       |
 | RCON_PORT                                 | RCONPort                             | Port number for RCON                                                                                                                                              | 25575                                                  | Integer       |
 | REGION                                    | Region                               | Area                                                                                                                                                              |                                                        | String        |
@@ -365,8 +369,116 @@ Complete Save
 - Keep the `--rm` in the command line, or you will have many exited containers in your list. 
 - All RCON-Commands can be research here: https://tech.palworldgame.com/server-commands
 
-### Usage with Portainer
-Soon ... see #39
+### Gameserver running from Portainer
+For Portainer it is recommended to use the Portainer-Stacks feature, which allows you to deploy a stack from a docker-compose.yml file.
+This configuration will allow you to use the one-click console access feature of Portainer.
+
+```yaml
+version: "3.9"
+services:
+  palworld-dedicated-server:
+    build: .
+    container_name: palworld-dedicated-server
+    image: jammsen/palworld-dedicated-server:latest
+    restart: unless-stopped
+    network_mode: bridge
+    ports:
+      - target: 8211 # The port inside the container where the game server is running
+        published: 8211 # The port on your host machine that maps to the game server port in the container
+        protocol: udp
+        mode: host
+      - target: 25575 # The port inside the container where the RCON server is running
+        published: 25575 # The port on your host machine that maps to the RCON server port in the container
+        protocol: tcp
+        mode: host
+    environment:
+      - TZ=Europe/Berlin # Change this for logging and backup, see "Environment-Variables" 
+      - ALWAYS_UPDATE_ON_START=true
+      - MULTITHREAD_ENABLED=true
+      - COMMUNITY_SERVER=true
+      - BACKUP_ENABLED=true
+      - BACKUP_CRON_EXPRESSION=0 * * * *
+      - NETSERVERMAXTICKRATE=120
+      - DIFFICULTY=None
+      - DAYTIME_SPEEDRATE=1.000000
+      - NIGHTTIME_SPEEDRATE=1.000000
+      - EXP_RATE=1.000000
+      - PAL_CAPTURE_RATE=1.000000
+      - PAL_SPAWN_NUM_RATE=1.000000
+      - PAL_DAMAGE_RATE_ATTACK=1.000000
+      - PAL_DAMAGE_RATE_DEFENSE=1.000000
+      - PLAYER_DAMAGE_RATE_ATTACK=1.000000
+      - PLAYER_DAMAGE_RATE_DEFENSE=1.000000
+      - PLAYER_STOMACH_DECREASE_RATE=1.000000
+      - PLAYER_STAMINA_DECREACE_RATE=1.000000
+      - PLAYER_AUTO_HP_REGENE_RATE=1.000000
+      - PLAYER_AUTO_HP_REGENE_RATE_IN_SLEEP=1.000000
+      - PAL_STOMACH_DECREACE_RATE=1.000000
+      - PAL_STAMINA_DECREACE_RATE=1.000000
+      - PAL_AUTO_HP_REGENE_RATE=1.000000
+      - PAL_AUTO_HP_REGENE_RATE_IN_SLEEP=1.000000
+      - BUILD_OBJECT_DAMAGE_RATE=1.000000
+      - BUILD_OBJECT_DETERIORATION_DAMAGE_RATE=1.000000
+      - COLLECTION_DROP_RATE=1.000000
+      - COLLECTION_OBJECT_HP_RATE=1.000000
+      - COLLECTION_OBJECT_RESPAWN_SPEED_RATE=1.000000
+      - ENEMY_DROP_ITEM_RATE=1.000000
+      - DEATH_PENALTY=All
+      - ENABLE_PLAYER_TO_PLAYER_DAMAGE=false
+      - ENABLE_FRIENDLY_FIRE=false
+      - ENABLE_INVADER_ENEMY=true
+      - ACTIVE_UNKO=false
+      - ENABLE_AIM_ASSIST_PAD=true
+      - ENABLE_AIM_ASSIST_KEYBOARD=false
+      - DROP_ITEM_MAX_NUM=3000
+      - DROP_ITEM_MAX_NUM_UNKO=100
+      - BASE_CAMP_MAX_NUM=128
+      - BASE_CAMP_WORKER_MAXNUM=15
+      - DROP_ITEM_ALIVE_MAX_HOURS=1.000000 
+      - AUTO_RESET_GUILD_NO_ONLINE_PLAYERS=false
+      - AUTO_RESET_GUILD_TIME_NO_ONLINE_PLAYERS=72.000000
+      - GUILD_PLAYER_MAX_NUM=20
+      - PAL_EGG_DEFAULT_HATCHING_TIME=72.000000
+      - WORK_SPEED_RATE=1.000000 
+      - IS_MULTIPLAY=false
+      - IS_PVP=false
+      - CAN_PICKUP_OTHER_GUILD_DEATH_PENALTY_DROP=false
+      - ENABLE_NON_LOGIN_PENALTY=true
+      - ENABLE_FAST_TRAVEL=true
+      - IS_START_LOCATION_SELECT_BY_MAP=true
+      - EXIST_PLAYER_AFTER_LOGOUT=false
+      - ENABLE_DEFENSE_OTHER_GUILD_PLAYER=false
+      - COOP_PLAYER_MAX_NUM=4
+      - MAX_PLAYERS=32
+      - SERVER_NAME=jammsen-docker-generated-###RANDOM###
+      - SERVER_DESCRIPTION=Palworld-Dedicated-Server running in Docker by jammsen
+      - ADMIN_PASSWORD=adminPasswordHere
+      - SERVER_PASSWORD=serverPasswordHere
+      - PUBLIC_PORT=8211
+      - PUBLIC_IP=
+      - RCON_ENABLED=false
+      - RCON_PORT=25575
+      - REGION=
+      - USEAUTH=true
+      - BAN_LIST_URL=https://api.palworldgame.com/api/banlist.txt
+    volumes:
+      - /path/to/your/game/directory:/palworld
+
+  rcon:
+    image: outdead/rcon:latest
+    container_name: palworld-rcon
+    restart: unless-stopped
+    entrypoint: ["/rcon", "-a", "RCON_ADDRESS:RCON_PORT", "-p", "RCON_PASSWORD"]
+    # "/rcon" is the command to start the RCON client
+    # "-a" is used to specify the address of the RCON server in the format "IP:PORT"
+    # "RCON_ADDRESS:RCON_PORT" should be replaced with the actual address and port of the RCON server
+    # "-p" is used to specify the password for the RCON server
+    # "RCON_PASSWORD" should be replaced with the actual RCON password
+    tty: true
+    stdin_open: true
+    depends_on:
+      - palworld-dedicated-server
+```
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ ___
   - [Standalone Game Server](#standalone-gameserver)
   - [Game Server with RCON](#gameserver-with-rcon)
     - [Running RCON Commands](#run-rcon-commands)
-  - [Usage with Portainer (Coming Soon)](#usage-with-portainer)
+  - [Usage with Portainer](#usage-with-portainer)
 - [Frequently Asked Questions](#faq)
 - [Future Plans](#planned-features-in-the-future)
 - [Software Used](#software-used)


### PR DESCRIPTION
Hello, this is the third commit based on our talk in VC yesterday @jammsen, from issues #33 and #39.

I have added the Portainer configuration as per our agreement, I have also updated it to be in sync with your newest commits and made the examples more in-line with your other previous docker-compose files.

I have also cleaned up the README.MD file as a whole as it sometimes it was using asterisk and some other times lines to determine the dot-points, which was not consistent. And I have also changed the English wording on some phrases to what I think it's easier to understand. Let me know!