### PR TITLE
Fix incorrect variable expansion when parsing PalServer.sh start options

### DIFF
--- a/scripts/servermanager.sh
+++ b/scripts/servermanager.sh
@@ -17,19 +17,19 @@ function start_server() {
     es ">>> Starting the gameserver\n"
     cd "$GAME_ROOT" || exit
     setup_configs
-    START_OPTIONS=""
+    START_OPTIONS=()
     if [[ -n $COMMUNITY_SERVER ]] && [[ $COMMUNITY_SERVER == "true" ]]; then
         ei "> Setting Community-Mode to enabled\n"
-        START_OPTIONS="$START_OPTIONS EpicApp=PalServer"
+        START_OPTIONS+=("EpicApp=PalServer")
     fi
     if [[ -n $MULTITHREAD_ENABLED ]] && [[ $MULTITHREAD_ENABLED == "true" ]]; then
         ei "> Setting Multi-Core-Enhancements to enabled\n"
-        START_OPTIONS="$START_OPTIONS -useperfthreads -NoAsyncLoadingThread -UseMultithreadForDS"
+        START_OPTIONS+=("-useperfthreads" "-NoAsyncLoadingThread" "-UseMultithreadForDS")
     fi
     if [[ -n $WEBHOOK_ENABLED ]] && [[ $WEBHOOK_ENABLED == "true" ]]; then
         send_start_notification
     fi
-    ./PalServer.sh "$START_OPTIONS"
+    ./PalServer.sh "${START_OPTIONS[@]}"
 }
 
 function stop_server() {


### PR DESCRIPTION
The way the script is currently implemented, it passes all of the start options as one quoted string to `PalServer.sh`. This results in Palworld itself setting all of the options (including spaces) as a single argument, leading to the options not being properly applied.

This PR changes `START_OPTIONS` to a Bash array, where the required options are added incrementally as required to the array, and when ready, the whole array is expanded as individual arguments to `PalServer.sh`.

Fixes #186.