### PR TITLE
Fix/permissions/only when required

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -191,6 +191,12 @@ COPY --chmod=755 configs/rcon.yaml /home/steam/steamcmd/rcon.yaml
 COPY --chmod=755 configs/PalWorldSettings.ini.template /
 COPY --chmod=755 gosu-amd64 /usr/local/bin/gosu
 
+RUN chown -R "$PUID:$PGID" "/home/steam/" && \
+    chown "$PUID:$PGID" /entrypoint.sh && \
+    chown "$PUID:$PGID" /PalWorldSettings.ini.template && \
+    chown -R "$PUID:$PGID" /scripts && \
+    chown -R "$PUID:$PGID" /includes
+
 RUN mkdir -p "$BACKUP_PATH" \
     && ln -s /scripts/backupmanager.sh /usr/local/bin/backup \
     && ln -s /scripts/rconcli.sh /usr/local/bin/rconcli \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
- RUN curl -fsSLO "$SUPERCRONIC_URL" \
+RUN curl -fsSLO "$SUPERCRONIC_URL" \
     && echo "${SUPERCRONIC_SHA1SUM}  ${SUPERCRONIC}" | sha1sum -c - \
     && chmod +x "$SUPERCRONIC" \
     && mv "$SUPERCRONIC" "/usr/local/bin/${SUPERCRONIC}" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -8,26 +8,34 @@ APP_GROUP=steam
 APP_HOME=/home/$APP_USER
 
 source /includes/colors.sh
+source /includes/permissions.sh
 
 if [[ "${PUID}" -eq 0 ]] || [[ "${PGID}" -eq 0 ]]; then
-    ee ">>> Running as root is not supported, please fix your PUID and PGID!"
+    ee ">>> Running Palworld as root is not supported, please fix your PUID and PGID!"
     exit 1
 elif [[ "$(id -u steam)" -ne "${PUID}" ]] || [[ "$(id -g steam)" -ne "${PGID}" ]]; then
     ew "> Current $APP_USER user PUID is '$(id -u steam)' and PGID is '$(id -g steam)'"
     ew "> Setting new $APP_USER user PUID to '${PUID}' and PGID to '${PGID}'"
     groupmod -g "${PGID}" "$APP_GROUP" && usermod -u "${PUID}" -g "${PGID}" "$APP_USER"
-else 
+else
     ew "> Current $APP_USER user PUID is '$(id -u steam)' and PGID is '$(id -g steam)'"
     ew "> PUID and PGID matching what is requested for user $APP_USER"
 fi
 
-chown -R "$APP_USER":"$APP_GROUP" "$APP_HOME"
-chown -R "$APP_USER":"$APP_GROUP" "$GAME_ROOT"
-chown "$APP_USER":"$APP_GROUP" /entrypoint.sh
-chown "$APP_USER":"$APP_GROUP" /PalWorldSettings.ini.template
-chown -R "$APP_USER":"$APP_GROUP" /scripts
-chown -R "$APP_USER":"$APP_GROUP" /includes
+change_ownership $APP_USER $APP_GROUP "$APP_HOME"
+change_ownership $APP_USER $APP_GROUP "$GAME_ROOT"
+change_ownership $APP_USER $APP_GROUP /entrypoint.sh
+change_ownership $APP_USER $APP_GROUP /PalWorldSettings.ini.template
+change_ownership $APP_USER $APP_GROUP /scripts
+change_ownership $APP_USER $APP_GROUP /includes
 
-ew_nn "> id steam: " ; e "$(id steam)"
+ew_nn "> id steam: "
+e "$(id steam)"
 
-exec gosu $APP_USER:$APP_GROUP "$@"
+if [ "$(id -u)" -eq 0 ]; then
+    ei "> Running Palworld as $APP_USER:$APP_GROUP (via gosu)"
+    exec gosu $APP_USER:$APP_GROUP "$@"
+else
+    ei "> Running Palworld as $(id -un):$(id -gn) (current user)"
+    exec "$@"
+fi

--- a/includes/permissions.sh
+++ b/includes/permissions.sh
@@ -14,11 +14,7 @@ change_ownership() {
     else
         # Echo the total count of files_with_incorrect_permissions
         count=$(echo "$files_with_incorrect_permissions" | wc -l)
-        ei "> Found $count items with improper permissions"
-
-        # Echo the files_with_incorrect_permissions to stdout
-        ei "> Files with incorrect permissions:"
-        ei "> $files_with_incorrect_permissions"
+        ei "> Found $count items with improper permissions for $TARGET"
 
         # Check if running as root and warn user if not
         if [ "$EUID" -ne 0 ]; then
@@ -30,6 +26,6 @@ change_ownership() {
             chown -R "$APP_USER:$APP_GROUP" "$TARGET"
         fi
 
-        echo "> Ownership changed to $APP_USER:$APP_GROUP for all items in $TARGET."
+        ei "> Ownership changed to $APP_USER:$APP_GROUP for all items in $TARGET."
     fi
 }

--- a/includes/permissions.sh
+++ b/includes/permissions.sh
@@ -1,0 +1,35 @@
+# shellcheck disable=SC2148
+
+# Changes the ownership to $APP_USER:$APP_GROUP for the given file / recursively to the given folder
+change_ownership() {
+    local APP_USER="$1"
+    local APP_GROUP="$2"
+    local TARGET="$3"
+
+    # Find files or directories not owned by specified user and group
+    files_with_incorrect_permissions=$(find "$TARGET" ! -user "$APP_USER" -o ! -group "$APP_GROUP")
+
+    if [ -z "$files_with_incorrect_permissions" ]; then
+        ei "> All items in $TARGET are already owned by $APP_USER:$APP_GROUP."
+    else
+        # Echo the total count of files_with_incorrect_permissions
+        count=$(echo "$files_with_incorrect_permissions" | wc -l)
+        ei "> Found $count items with improper permissions"
+
+        # Echo the files_with_incorrect_permissions to stdout
+        ei "> Files with incorrect permissions:"
+        ei "> $files_with_incorrect_permissions"
+
+        # Check if running as root and warn user if not
+        if [ "$EUID" -ne 0 ]; then
+            ee "> Cannot fix ownership unless container is ran as root. This is a separate setting from the PUID and PGID environmental variables."
+            exit 1
+        else
+            # Change ownership recursively to specified user and group
+            ei "> Changing ownership..."
+            chown -R "$APP_USER:$APP_GROUP" "$TARGET"
+        fi
+
+        echo "> Ownership changed to $APP_USER:$APP_GROUP for all items in $TARGET."
+    fi
+}

--- a/includes/security.sh
+++ b/includes/security.sh
@@ -5,11 +5,11 @@ source /includes/colors.sh
 function check_for_default_credentials() {
     e "> Checking for existence of default credentials"
     if [[ -n $ADMIN_PASSWORD ]] && [[ $ADMIN_PASSWORD == "adminPasswordHere" ]]; then
-        ee ">>> Security thread detected: Please change the default admin password. Aborting server start ..."
+        ee ">>> Security threat detected: Please change the default admin password. Aborting server start ..."
         exit 1
     fi
     if [[ -n $SERVER_PASSWORD ]] && [[ $SERVER_PASSWORD == "serverPasswordHere" ]]; then
-        ee ">>> Security thread detected: Please change the default server password. Aborting server start ..."
+        ee ">>> Security threat detected: Please change the default server password. Aborting server start ..."
         exit 1
     fi
     es "> No default passwords found"


### PR DESCRIPTION
# What

- Updates the file permissions only when needed
- Allow container to run as a non-root user as long as the file permissions are proper
- Adds error message when trying to update file permissions but not running as root
- Clarified message about `PUID` and `PGID` not being root
- Fixed typo `Security thread` -> `Security threat`
- Remove extra space in front of one of the `RUN` commands


## What it looks like when running container as steam but file permissions are wrong

New: 
![image](https://github.com/jammsen/docker-palworld-dedicated-server/assets/45444205/9468f60a-1489-432d-8f3b-d5092565063f)


Old:
![image](https://github.com/jammsen/docker-palworld-dedicated-server/assets/45444205/d11eee5a-035d-4e1e-ae1b-6c3ff2d0ef9e)

## What it looks like when ran as steam and file permissions are correct
![image](https://github.com/jammsen/docker-palworld-dedicated-server/assets/45444205/a5ec0a29-0f80-4e68-a241-48a5bffe383a)


## What it looks like when ran as root and file permissions are correct
![image](https://github.com/jammsen/docker-palworld-dedicated-server/assets/45444205/56c21bc9-6213-433c-b8dd-aec1f1d18b76)


# Why

- I did not understand the error messages when I ran into #203 and from the discord it seems to be confusing others. The new error message should help people understand the underlying issue better than previous "Operation not permitted"
- Allows advanced users to run the container not as root such as requested in https://github.com/jammsen/docker-palworld-dedicated-server/issues/203#issuecomment-1948244499


# Notes

- I am still pretty new to Docker so not sure if my changes to the `Dockerfile` changed the layers in a bad way
- Screenshots taken from Portainer