### PR TITLE
Minimise user write access to container service files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -187,8 +187,8 @@ RUN apt-get update \
 COPY --chmod=755 entrypoint.sh /
 COPY --chmod=755 scripts/ /scripts
 COPY --chmod=755 includes/ /includes
-COPY --chmod=755 configs/rcon.yaml /home/steam/steamcmd/rcon.yaml
-COPY --chmod=755 configs/PalWorldSettings.ini.template /
+COPY --chmod=644 configs/rcon.yaml /home/steam/steamcmd/rcon.yaml
+COPY --chmod=644 configs/PalWorldSettings.ini.template /
 COPY --chmod=755 gosu-amd64 /usr/local/bin/gosu
 
 RUN mkdir -p "$BACKUP_PATH" \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,17 +16,13 @@ elif [[ "$(id -u steam)" -ne "${PUID}" ]] || [[ "$(id -g steam)" -ne "${PGID}" ]
     ew "> Current $APP_USER user PUID is '$(id -u steam)' and PGID is '$(id -g steam)'"
     ew "> Setting new $APP_USER user PUID to '${PUID}' and PGID to '${PGID}'"
     groupmod -g "${PGID}" "$APP_GROUP" && usermod -u "${PUID}" -g "${PGID}" "$APP_USER"
-else 
+else
     ew "> Current $APP_USER user PUID is '$(id -u steam)' and PGID is '$(id -g steam)'"
     ew "> PUID and PGID matching what is requested for user $APP_USER"
 fi
 
 chown -R "$APP_USER":"$APP_GROUP" "$APP_HOME"
 chown -R "$APP_USER":"$APP_GROUP" "$GAME_ROOT"
-chown "$APP_USER":"$APP_GROUP" /entrypoint.sh
-chown "$APP_USER":"$APP_GROUP" /PalWorldSettings.ini.template
-chown -R "$APP_USER":"$APP_GROUP" /scripts
-chown -R "$APP_USER":"$APP_GROUP" /includes
 
 ew_nn "> id steam: " ; e "$(id steam)"
 

--- a/includes/config.sh
+++ b/includes/config.sh
@@ -40,7 +40,7 @@ function setup_palworld_settings_ini() {
     fi
     # Copy default-config, which comes with SteamCMD to gameserver save location
     ew "> Copying PalWorldSettings.ini.template to ${GAME_SETTINGS_FILE}"
-    cp "${PALWORLD_TEMPLATE_FILE}" "${GAME_SETTINGS_FILE}"
+    cp --no-preserve=ownership "${PALWORLD_TEMPLATE_FILE}" "${GAME_SETTINGS_FILE}"
 
     if [[ -n ${DIFFICULTY+x} ]]; then
         e "> Setting Difficulty to '$DIFFICULTY'"


### PR DESCRIPTION
This PR reduces the number of files that the container user is given write access to before the user jail is started.

This reduces the risk of files being modified by potential attackers if they managed to break into the container environment (through, for example, a vulnerability in Palworld.)

The following files/directories have had their ownership changed to `root:root`:

* `/entrypoint.sh`
* `/PalWorldSettings.ini.template`
* `/scripts`
* `/includes`

The container user still has full read access to these files. `PalWorldSettings.ini.template` is still copied by the user to the Palworld config dir (with correct ownership), and `server.sh` can set configuration values in it without issues. The only thing that has changed is that the container user can no longer *modify* these files.

`PalWorldSettings.ini.template` and `rcon.yaml` have also had execute permissions removed, as they do not need to be executable.