### PR TITLE
feat(error): throw when not running as root

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,6 +9,11 @@ APP_HOME=/home/$APP_USER
 
 source /includes/colors.sh
 
+if [[ "${EUID}" -ne 0 ]]; then
+    ee ">>> Docker user must be root! Please adjust how you started the container."
+    exit 1
+fi
+
 if [[ "${PUID}" -eq 0 ]] || [[ "${PGID}" -eq 0 ]]; then
     ee ">>> Running Palworld as root is not supported, please fix your PUID and PGID!"
     exit 1
@@ -16,7 +21,7 @@ elif [[ "$(id -u steam)" -ne "${PUID}" ]] || [[ "$(id -g steam)" -ne "${PGID}" ]
     ew "> Current $APP_USER user PUID is '$(id -u steam)' and PGID is '$(id -g steam)'"
     ew "> Setting new $APP_USER user PUID to '${PUID}' and PGID to '${PGID}'"
     groupmod -g "${PGID}" "$APP_GROUP" && usermod -u "${PUID}" -g "${PGID}" "$APP_USER"
-else 
+else
     ew "> Current $APP_USER user PUID is '$(id -u steam)' and PGID is '$(id -g steam)'"
     ew "> PUID and PGID matching what is requested for user $APP_USER"
 fi
@@ -28,6 +33,7 @@ chown "$APP_USER":"$APP_GROUP" /PalWorldSettings.ini.template
 chown -R "$APP_USER":"$APP_GROUP" /scripts
 chown -R "$APP_USER":"$APP_GROUP" /includes
 
-ew_nn "> id steam: " ; e "$(id steam)"
+ew_nn "> id steam: "
+e "$(id steam)"
 
 exec gosu $APP_USER:$APP_GROUP "$@"


### PR DESCRIPTION
Breaking up #240 into smaller PRs

Much simpler implementation of the intent of #240. This simply checks if the container is running as root and throws a user friendly error if its not. The purpose of this is that the container is designed to be ran as root and can throw errors which are not docker beginner friendly if ran not as root such as in #203. More details below.

This screenshot shows what happens when ran as not root and then that it still works when ran as root. It does throw an error because I did not set the env vars for the test but shows it gets past the if statement I added.

![image](https://github.com/jammsen/docker-palworld-dedicated-server/assets/45444205/797aae1e-8362-4f8d-98ff-cbf8b36cc5be)


## More details

The intent is to let the user know they need run the container as root as in the [`--user` if using docker run](https://docs.docker.com/engine/reference/run/#user). Note if using docker run then leaving the arg out completely will default to root.

If using docker compose as I would assume most are, ensure they didn't define [`user` in their compose file](https://docs.docker.com/compose/compose-file/compose-file-v3/#domainname-hostname-ipc-mac_address-privileged-read_only-shm_size-stdin_open-tty-user-working_dir).

If using portainer, ensuring [the `user` setting in advanced container settings](https://docs.portainer.io/user/docker/containers/advanced), does not have a non-root user in it. 

If anyone has any suggestions as to how best to convey that in the error message, I won't be offended.
