### PR TITLE
Exclude save backup directory in backup

### DIFF
--- a/scripts/backupmanager.sh
+++ b/scripts/backupmanager.sh
@@ -144,7 +144,7 @@ function create_backup() {
     sleep 15
     rconcli broadcast "$(get_time) Creating backup..."
 
-    if ! tar cfz "${LOCAL_BACKUP_PATH}/${backup_file_name}" -C "${LOCAL_GAME_PATH}/" "Saved" ; then
+    if ! tar cfz "${LOCAL_BACKUP_PATH}/${backup_file_name}" -C "${LOCAL_GAME_PATH}/" --exclude "backup" "Saved" ; then
         broadcast_backup_failed
         ee ">>> Backup failed"
     else


### PR DESCRIPTION
# Test

1. Set `ENABLE_WORLD_BACKUP=true`
2. Start the server and wait for a backup to be made by the game
3. Run the backup command `docker exec -it -u steam palworld-dedicated-server backup create`
4. Verify the backup does not contain the backup directory in the saved game data