### PR TITLE
feat: log rotation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     logging:
       driver: "local"
       options:
-        max-size: "100m"
+        max-size: "10m"
         max-file: "3"
     ports:
       - target: 8211 # Gamerserver port inside of the container

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,11 @@ services:
     container_name: palworld-dedicated-server
     image: jammsen/palworld-dedicated-server:latest
     restart: unless-stopped
+    logging:
+      driver: "local"
+      options:
+        max-size: "100m"
+        max-file: "3"
     ports:
       - target: 8211 # Gamerserver port inside of the container
         published: 8211 # Gamerserver port on your host


### PR DESCRIPTION
This Pr adds log rotation as the default log driver does not include it.

This is nice when your server goes into a crash loop and creates lots of logs in the process.

The values are set very high so that under normal circumstances you should not be affected by the rotation, it is meant more as a backstop in case somethnig goes very wrong


further reference: https://docs.docker.com/config/containers/logging/configure/