### PR TITLE
set default SERVER_SETTINGS_MODE=auto

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,7 +100,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     WEBHOOK_UPDATE_DESCRIPTION="Server is being updated" \
     WEBHOOK_UPDATE_COLOR="2849520" \
     # Config-setting - Warning: Every setting below here will be affected!
-    SERVER_SETTINGS_MODE=manual \
+    SERVER_SETTINGS_MODE=auto \
     # Gameserver-start-settings
     MULTITHREAD_ENABLED=true \
     COMMUNITY_SERVER=true \


### PR DESCRIPTION
Hi,

After reading the discord guidelines I realized that it was more suitable to file something on GitHub (sorry about the noise in chat).

It is my understanding that the default SERVER_SETTINGS_MODE should be `auto` based on [these docs](https://github.com/Radical-Egg/docker-palworld-dedicated-server/blob/develop/docs/ENV_VARS.md). 

>Important: If you want to change the server settings via environment variables use the default value (auto) for the environment variable SERVER_SETTINGS_MODE, otherwise change it to manual and edit the config file directly

It seems that the current default is set to `manual` in the Dockerfile. When I attempted to run my dedicated server for the first time, I was having trouble figuring out how to change settings because I used my own default.env file and not the one inside of this repo.


```bash
# custom.default.env
egg蛋ada docker-palworld-dedicated-server on  develop [!?]
❯ cat custom.default.env
PUID=1000
PGID=1000
TZ=America/Los_Angeles
STEAMCMD_VALIDATE_FILES=true
BACKUP_ENABLED=true
ADMIN_PASSWORD=new_admin_pass123
SERVER_PASSWORD=new_server_pass123
COMMUNITY_SERVER=false
MULTITHREAD_ENABLED=true
SERVER_NAME="My dedicated server"
```

```bash
# docker-compose.yml
egg蛋ada docker-palworld-dedicated-server on  develop [!?]
❯ cat docker-compose.yml
version: '3.9'
services:
  palworld-dedicated-server:
    container_name: palworld-dedicated-server-test
    image: jammsen/palworld-dedicated-server:latest
    restart: unless-stopped
    ports:
      - target: 8211 # Gamerserver port inside of the container
        published: 8211 # Gamerserver port on your host
        protocol: udp
        mode: host
      - target: 8212 # Gameserver API port inside of the container
        published: 8212 # Gameserver API port on your host
        protocol: tcp
        mode: host
      - target: 25575 # RCON port inside of the container
        published: 25575 # RCON port on your host
        protocol: tcp
        mode: host
    env_file:
      - ./custom.default.env
    volumes:
      - ./game:/palworld
```

Unexpected:

```bash
palworld-dedicated-server-test  | >>> SERVER_SETTINGS_MODE is set to 'manual', NOT using environment variables to configure the server!
``` 

Changing SERVER_SETTINGS_MODE=auto in the Dockerfile has the behavior that I expected based on the docs.

```bash
palworld-dedicated-server-test  | >>> SERVER_SETTINGS_MODE is set to 'auto', using environment variables to configure the server
````

Thanks for the cool project!

