### PR TITLE
fix(startup) Don't fail if appmanifest doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 [Back to main](README.md#changelog)
+## 2025-01-11
+
+- Fixed startup script failure if missing appmanifest @holysoles (#288)
+
 ## 2024-12-23
 
 - added new configs for Palworld: Feybreak @jammsen (#283)

--- a/includes/server.sh
+++ b/includes/server.sh
@@ -51,7 +51,7 @@ function fresh_install_server() {
 function update_server() {
     # Workaround fix for 0x6 error
     ei ">>> Applying workaround fix for 'Error! App '2394010' state is 0x6 after update job.' message, since update 0.3.X..."
-    rm /palworld/steamapps/appmanifest_2394010.acf
+    rm -f /palworld/steamapps/appmanifest_2394010.acf
     if [[ -n $STEAMCMD_VALIDATE_FILES ]] && [[ $STEAMCMD_VALIDATE_FILES == "true" ]]; then
         ei ">>> Doing an update with validation of the gameserver files..."
         if [[ -n $WEBHOOK_ENABLED ]] && [[ $WEBHOOK_ENABLED == "true" ]]; then


### PR DESCRIPTION
The attempted fix for the `'Error! App '2394010' state is 0x6 after update job.'` issue will cause the container to fail startup and exit if the expected file in the `rm` command doesn't exist:

```
rm: cannot remove '/palworld/steamapps/appmanifest_2394010.acf': No such file or directory
```

This PR updates the remove command to include `-f`, so that it still exits 0 if the file is not present.

I've tested this on my own setup and has worked well, but feel free to suggest additional testing scenarios for me to try.