### PR TITLE
Update workflows to enable builds from fork

### DIFF
--- a/.github/workflows/docker-build-and-push-develop.yml
+++ b/.github/workflows/docker-build-and-push-develop.yml
@@ -19,17 +19,20 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Get short SHA
+        id: slug
+        run: echo "GIT_SHORT_SHA7=$(echo ${GITHUB_SHA} | cut -c1-7)" >> "$GITHUB_OUTPUT"
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: |
-            jammsen/palworld-dedicated-server
+            ${{ secrets.DOCKERHUB_USERNAME }}/palworld-dedicated-server
             ghcr.io/${{ github.repository }}
-
-      - name: Get short SHA
-        id: slug
-        run: echo "GIT_SHORT_SHA7=$(echo ${GITHUB_SHA} | cut -c1-7)" >> "$GITHUB_OUTPUT"
+          tags: |
+            type=ref,event=branch
+            type=raw,value=${{ steps.slug.outputs.GIT_SHORT_SHA7 }}
 
       - name: Build the images
         uses: docker/build-push-action@v5
@@ -37,10 +40,7 @@ jobs:
           context: .
           push: false
           load: true
-          tags: |
-            ${{ steps.meta.outputs.tags }}
-            ${{ secrets.DOCKERHUB_USERNAME }}/palworld-dedicated-server:${{ steps.slug.outputs.GIT_SHORT_SHA7 }}
-            ghcr.io/${{ secrets.DOCKERHUB_USERNAME }}/docker-palworld-dedicated-server:${{ steps.slug.outputs.GIT_SHORT_SHA7 }}
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Run unit tests
@@ -67,8 +67,5 @@ jobs:
         with:
           context: .
           push: true
-          tags: |
-            ${{ steps.meta.outputs.tags }}
-            ${{ secrets.DOCKERHUB_USERNAME }}/palworld-dedicated-server:${{ steps.slug.outputs.GIT_SHORT_SHA7 }}
-            ghcr.io/${{ secrets.DOCKERHUB_USERNAME }}/docker-palworld-dedicated-server:${{ steps.slug.outputs.GIT_SHORT_SHA7 }}
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-build-and-push-prod.yml
+++ b/.github/workflows/docker-build-and-push-prod.yml
@@ -19,17 +19,22 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Get short SHA
+        id: slug
+        run: echo "GIT_SHORT_SHA7=$(echo ${GITHUB_SHA} | cut -c1-7)" >> "$GITHUB_OUTPUT"
+
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: |
-            jammsen/palworld-dedicated-server
+            ${{ secrets.DOCKERHUB_USERNAME }}/palworld-dedicated-server
             ghcr.io/${{ github.repository }}
-
-      - name: Get short SHA
-        id: slug
-        run: echo "GIT_SHORT_SHA7=$(echo ${GITHUB_SHA} | cut -c1-7)" >> "$GITHUB_OUTPUT"
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=raw,value=${{ steps.slug.outputs.GIT_SHORT_SHA7 }}
+            type=raw,value=latest
 
       - name: Build the images
         uses: docker/build-push-action@v5
@@ -37,12 +42,7 @@ jobs:
           context: .
           push: false
           load: true
-          tags: |
-            ${{ steps.meta.outputs.tags }}
-            ${{ secrets.DOCKERHUB_USERNAME }}/palworld-dedicated-server:${{ steps.slug.outputs.GIT_SHORT_SHA7 }}
-            ${{ secrets.DOCKERHUB_USERNAME }}/palworld-dedicated-server:latest
-            ghcr.io/${{ secrets.DOCKERHUB_USERNAME }}/docker-palworld-dedicated-server:${{ steps.slug.outputs.GIT_SHORT_SHA7 }}
-            ghcr.io/${{ secrets.DOCKERHUB_USERNAME }}/docker-palworld-dedicated-server:latest
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Run unit tests
@@ -69,12 +69,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: |
-            ${{ steps.meta.outputs.tags }}
-            ${{ secrets.DOCKERHUB_USERNAME }}/palworld-dedicated-server:${{ steps.slug.outputs.GIT_SHORT_SHA7 }}
-            ${{ secrets.DOCKERHUB_USERNAME }}/palworld-dedicated-server:latest
-            ghcr.io/${{ secrets.DOCKERHUB_USERNAME }}/docker-palworld-dedicated-server:${{ steps.slug.outputs.GIT_SHORT_SHA7 }}
-            ghcr.io/${{ secrets.DOCKERHUB_USERNAME }}/docker-palworld-dedicated-server:latest
+          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
       - name: Docker Hub Description
@@ -82,6 +77,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: jammsen//palworld-dedicated-server
+          repository: ${{ secrets.DOCKERHUB_USERNAME }}//palworld-dedicated-server
           readme-filepath: ./README.md
           enable-url-completion: true


### PR DESCRIPTION
- Move tag creation under docker/metadata-action
- Removed defaulted `type=schedule`, `type=ref,event=tag`, `type=ref,event=pr` from docker-build-and-push-develop.yml
- Removed defaulted `type=schedule`, `type=ref,event=pr` from docker-build-and-push-prod.yml (but `event=tag` won't work unless an `on.push.tags` is added to the top of the workflow file)
